### PR TITLE
Update to new nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,23 +13,15 @@ matrix:
     - rust: stable
     - rust: nightly
       script:
-        - cargo test
-        - cargo test --manifest-path examples/alloc-shim/Cargo.toml
-        - cargo test --manifest-path examples/other-way/Cargo.toml
-        - cargo test --manifest-path examples/alloc-shim/Cargo.toml --features=std
-        - cargo test --manifest-path examples/other-way/Cargo.toml --features=std
-        - cargo test --manifest-path examples/alloc-shim/Cargo.toml --features=alloc,nightly
-        - cargo test --manifest-path examples/other-way/Cargo.toml --features=alloc
-        - cargo test --features=std,alloc
-        - cargo test --manifest-path examples/alloc-shim/Cargo.toml --features=std,alloc
-        - cargo test --all-features
-        - cargo test --manifest-path examples/alloc-shim/Cargo.toml --all-features
-        - cargo test --manifest-path examples/other-way/Cargo.toml --all-features
+        - cargo test --all
+        - cargo test --all --features=std
+        - cargo test --all --features=alloc
+        - cargo test --all --all-features
 
     - rust: nightly
       name: cargo clippy
       script:
-        - if rustup component add clippy-preview;
+        - if rustup component add clippy;
           then
             cargo clippy --all --all-features -- -Dwarnings;
           else
@@ -45,14 +37,8 @@ before_script:
   - set -o errexit
 
 script:
-  - cargo test
-  - cargo test --manifest-path examples/alloc-shim/Cargo.toml
-  - cargo test --manifest-path examples/other-way/Cargo.toml
-  - cargo test --features=std
-  - cargo test --manifest-path examples/alloc-shim/Cargo.toml --features=std
-  - cargo test --manifest-path examples/other-way/Cargo.toml --features=std
-  - cargo test --features=std,alloc
-  - cargo test --manifest-path examples/alloc-shim/Cargo.toml --features=std,alloc
+  - cargo test --all
+  - cargo test --all --features=std
 
 notifications:
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Unreleased
 
+* **This crate is deprecated.** You can now write:
+
+  ```rust
+  #![cfg_attr(feature = "alloc", feature(alloc))]
+
+  #[cfg(all(feature = "alloc", not(feature = "std")))]
+  extern crate alloc;
+  #[cfg(feature = "std")]
+  extern crate std as alloc;
+  ```
+
+* Update to new nightly.
+
 # 0.3.1 - 2019-02-18
 
 * Remove "futures" feature (Update to new nightly).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ exclude = ["/.travis.yml"]
 members = ["examples/other-way", "examples/alloc-shim"]
 
 [badges]
-# https://github.com/rust-lang/crates.io/issues/1392
-# travis-ci = { repository = "taiki-e/alloc-shim" }
+maintenance = { status = "deprecated" }
 
 [lib]
 name = "alloc"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@
 
 A shim crate for to import items of alloc crate ergonomically.
 
-[Examples](examples)
+**This crate is deprecated.** You can now write:
+
+```rust
+#![cfg_attr(feature = "alloc", feature(alloc))]
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std as alloc;
+```
 
 ## Usage
 
@@ -31,13 +40,6 @@ Add this to your crate root (lib.rs or main.rs):
 
 ```rust
 #![cfg_attr(feature = "alloc", feature(alloc))]
-```
-
-Now, you can use alloc-shim:
-
-```rust
-#[cfg(any(feature = "alloc", feature = "std"))]
-use alloc::prelude::*; // And more...
 ```
 
 The current version of alloc-shim requires Rust 1.31 or later.

--- a/examples/alloc-shim/Cargo.toml
+++ b/examples/alloc-shim/Cargo.toml
@@ -9,6 +9,5 @@ publish = false
 alloc-shim = { path = "../..", version = "0.3" }
 
 [features]
-std = ["alloc", "alloc-shim/std"]
+std = ["alloc-shim/std"]
 alloc = ["alloc-shim/alloc"]
-nightly = []

--- a/examples/alloc-shim/src/lib.rs
+++ b/examples/alloc-shim/src/lib.rs
@@ -1,17 +1,14 @@
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
-
-#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
-compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
+#![cfg_attr(feature = "alloc", feature(alloc))]
 
 #[test]
 fn core_fn() {
     pub use core::sync::atomic::AtomicPtr;
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn alloc_fn() {
-    pub use alloc::prelude::*;
+    pub use alloc::prelude::v1::*;
     pub use alloc::sync::Arc;
     pub use core::sync::atomic::AtomicPtr;
 

--- a/examples/other-way/src/lib.rs
+++ b/examples/other-way/src/lib.rs
@@ -1,15 +1,9 @@
 #![cfg_attr(feature = "alloc", feature(alloc))]
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
-
-#[cfg(any(feature = "alloc", feature = "std"))]
-mod alloc_shim {
-    #[cfg(not(feature = "std"))]
-    pub use crate::alloc::*;
-    #[cfg(feature = "std")]
-    pub use std::{prelude::v1 as prelude, *};
-}
+#[cfg(feature = "std")]
+extern crate std as alloc;
 
 #[test]
 fn core_fn() {
@@ -19,7 +13,8 @@ fn core_fn() {
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn alloc_fn() {
-    pub use crate::alloc_shim::sync::Arc;
+    pub use alloc::prelude::v1::*;
+    pub use alloc::sync::Arc;
     pub use core::sync::atomic::AtomicPtr;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,39 +1,17 @@
 //! A shim crate for to import items of alloc crate ergonomically.
 //!
-//! [Examples](https://github.com/taiki-e/alloc-shim/tree/master/examples)
-//!
-//! ## Usage
-//!
-//! Add this to your `Cargo.toml`:
-//!
-//! ```toml
-//! [dependencies]
-//! alloc-shim = "0.3.1"
-//! ```
-//!
-//! Set the features so that `std` depends on `alloc-shim/std`, and `alloc` depends on `alloc-shim/alloc`:
-//!
-//! ```toml
-//! [features]
-//! std = ["alloc-shim/std"]
-//! alloc = ["alloc-shim/alloc"]
-//! ```
-//!
-//! Add this to your crate root (lib.rs or main.rs):
-//!
-//! ```rust,ignore
-//! #![cfg_attr(feature = "alloc", feature(alloc))]
-//! ```
-//!
-//! Now, you can use alloc-shim:
+//! **This crate is deprecated.** You can now write:
 //!
 //! ```rust
-//! # #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
-//! #[cfg(any(feature = "alloc", feature = "std"))]
-//! use alloc::prelude::*; // And more...
+//! #![cfg_attr(feature = "alloc", feature(alloc))]
+//!
+//! #[cfg(all(feature = "alloc", not(feature = "std")))]
+//! extern crate alloc;
+//! #[cfg(feature = "std")]
+//! extern crate std as alloc;
 //! ```
 //!
-//! The current version of alloc-shim requires Rust 1.31 or later.
+//! [Examples](https://github.com/taiki-e/alloc-shim/tree/master/examples)
 //!
 //! ## Crate Features
 //!
@@ -49,60 +27,22 @@
 //!   * Note that `std` crate is used if both `std` and `alloc` are specified at the same time.
 //!   * This requires Rust Nightly.
 //!
-//! * `futures`
-//!   * Disabled by default.
-//!   * Enable to use `alloc::task`.
-//!   * This requires Rust Nightly.
-//!
 
 #![doc(html_root_url = "https://docs.rs/alloc-shim/0.3.1")]
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
+#![cfg_attr(
+    all(feature = "alloc", not(feature = "std")),
+    feature(alloc, alloc_prelude)
+)]
 #![deny(rust_2018_idioms)]
+#![deprecated(since = "0.3.2", note = "this crate is deprecated without replacement")]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc as liballoc;
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
-mod shim {
-    pub use liballoc::{
-        alloc, borrow, boxed, collections, fmt, format, rc, slice, str, string, vec,
-    };
-
-    /// Synchronization primitives
-    pub mod sync {
-        pub use liballoc::sync::*;
-
-        // `alloc::sync` does not include `atomic` module
-        // pub use core::sync::atomic;
-    }
-
-    // FIXME(taiki-e):
-    // `alloc::prelude` is required to use `#![feature(alloc)]` now.
-    // Should we rewrite it so that it can be used without specifying `#![feature(alloc)]`?
-    //
-    // /// The alloc Prelude
-    // pub mod prelude {
-    //    pub use liballoc::prelude::*;
-    // }
-    pub use liballoc::prelude;
-}
+pub use liballoc::*;
 
 #[cfg(feature = "std")]
-mod shim {
-    pub use std::{alloc, borrow, boxed, collections, fmt, format, rc, slice, str, string, vec};
-
-    /// Synchronization primitives
-    pub mod sync {
-        pub use std::sync::{Arc, Weak};
-
-        // `alloc::sync` does not include `atomic` module
-        // pub use std::sync::atomic;
-    }
-
-    // The layout in the prelude module is different for `std` and `alloc`.
-    /// The alloc Prelude
-    pub use std::prelude::v1 as prelude;
-}
-
-#[cfg(any(feature = "alloc", feature = "std"))]
-pub use self::shim::*;
+pub use std::{
+    alloc, borrow, boxed, collections, fmt, format, prelude, rc, slice, str, string, sync, vec,
+};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
+#![cfg_attr(
+    all(feature = "alloc", not(feature = "std")),
+    feature(alloc, alloc_prelude)
+)]
 #![deny(warnings)]
 #![deny(rust_2018_idioms)]
 #![allow(unused_imports)]
@@ -6,10 +9,7 @@
 #[cfg(any(feature = "alloc", feature = "std"))]
 mod test {
     use alloc::{
-        alloc as alloc_mod, borrow, boxed, collections, fmt, prelude, prelude::Box, prelude::Vec,
-        rc, slice, str, string, sync, sync::Arc, vec,
+        alloc as alloc_mod, borrow, boxed, collections, fmt, prelude::v1, prelude::v1::Box,
+        prelude::v1::Vec, rc, slice, str, string, sync, sync::Arc, vec,
     };
-
-    // `alloc::sync` does not include `atomic` module
-    // use alloc::sync::atomic;
 }


### PR DESCRIPTION
This crate is deprecated. You can now write:

```rust
#![cfg_attr(feature = "alloc", feature(alloc))]

#[cfg(all(feature = "alloc", not(feature = "std")))]
extern crate alloc;
#[cfg(feature = "std")]
extern crate std as alloc;
```